### PR TITLE
Handling optional parameters and google closure syntax

### DIFF
--- a/src/definitions.js
+++ b/src/definitions.js
@@ -1,13 +1,32 @@
 const { findType } = require('./type')
 const { getType } = require('./type')
 
-const getObjectProperties = (def, name, namespace) => {
-  const type = getType(def, namespace)
+/**
+ *
+ * @param {string} name
+ * @param {array<string>} [requiredProperties=[]]
+ * @return {boolean} param is required
+ */
+const isRequired = ({ name, requiredProperties = [] }) => {
+  return requiredProperties.includes(name)
+}
+
+/**
+ *
+ * @param {object} typeDefinition
+ * @param {string} name
+ * @param {string} namespace
+ * @param {boolean} required
+ * @return {*&{name, namespace, type: string, required}}
+ */
+const getObjectProperties = ({ typeDefinition, name, namespace, required }) => {
+  const type = getType(typeDefinition, namespace)
   return {
-    ...def,
+    ...typeDefinition,
     name,
     namespace,
     type,
+    required,
   }
 }
 const prepareDefinitions = (name, definition, namespace) => {
@@ -28,8 +47,22 @@ const prepareDefinitions = (name, definition, namespace) => {
     return {
       ...base,
       properties: Object.keys(base.properties || {}).reduce((arr, property) => {
-        const def = base.properties[property]
-        return arr.concat(getObjectProperties(def, property, namespace))
+        const typeDefinition = base.properties[property]
+        const required = Array.isArray(definition.required)
+          ? isRequired({
+              name: property,
+              requiredProperties: definition.required,
+            })
+          : true
+        return arr.concat(
+          getObjectProperties({
+            name: property,
+            typeDefinition,
+            property,
+            namespace,
+            required,
+          })
+        )
       }, []),
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,16 @@ const print = console.log
  * @param {string} url - example "https://petstore.swagger.io/v2/swagger.json"
  * @param {string} [output]
  * @param {string} [outputDirectory="output"]
+ * @param {boolean} [googleClosureSyntax=false]
  * @return {Promise<{outputPath: string}>}
  */
-async function init({ path, url, output, outputDirectory = 'output/' }) {
+async function init({
+  path,
+  url,
+  output,
+  outputDirectory = 'output/',
+  googleClosureSyntax = false,
+}) {
   try {
     const swagger = !!url
       ? await getRemoteSwagger({ url })
@@ -38,7 +45,7 @@ async function init({ path, url, output, outputDirectory = 'output/' }) {
     const contents = Object.keys(definitions).reduce((prev, name) => {
       const definition = definitions[name]
       const params = prepareDefinitions(name, definition, swaggerNamespace)
-      const currentJsDoc = renderJsDoc(params)
+      const currentJsDoc = renderJsDoc(params, { googleClosureSyntax })
       return prev + currentJsDoc
     }, base)
 
@@ -69,6 +76,7 @@ const prepare = () => {
     url: options.url,
     output: options.output,
     outputDirectory: options.outputDirectory,
+    googleClosureSyntax: options.googleClosureSyntax,
   })
     .then(({ outputPath }) => {
       print(messages.success({ outputPath }))

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -5,6 +5,12 @@ const optionDefinitions = [
   { name: 'outputDirectory', alias: 'd', type: String },
   { name: 'path', alias: 'p', type: String },
   { name: 'url', alias: 'u', type: String },
+  {
+    name: 'googleClosureSyntax',
+    alias: 'g',
+    type: Boolean,
+    defaultValue: false,
+  },
 ]
 /**
  *
@@ -12,7 +18,8 @@ const optionDefinitions = [
  *   output: string,
  *   outputDirectory: string,
  *   path: string,
- *   url: string
+ *   url: string,
+ *   googleClosureSyntax: boolean
  * }}
  */
 const getOptions = () => {

--- a/src/templates.js
+++ b/src/templates.js
@@ -30,8 +30,13 @@ const overridePropertyParams = (definitionParams) => {
   }
   return definitionParams
 }
-
-const paramsOverridesRoot = (definitionParams) => {
+/**
+ *
+ * @param definitionParams
+ * @param {{googleClosureSyntax: boolean}} options
+ * @return {(*&{enum: *})|(*&{properties: ((*&{type: *})|*)[]})|*}
+ */
+const paramsOverridesRoot = (definitionParams, options) => {
   if (isEnum(definitionParams)) {
     return {
       ...definitionParams,
@@ -44,13 +49,12 @@ const paramsOverridesRoot = (definitionParams) => {
   return {
     ...definitionParams,
     properties: definitionParams.properties.map((_definitionParams) => {
-      const propertyParams = _definitionParams
-      propertyParams.requirednessFlag = '='
-      if (
-        definitionParams.required &&
-        definitionParams.required.includes(propertyParams.name)
-      ) {
-        propertyParams.requirednessFlag = ''
+      const propertyParams = {
+        ..._definitionParams,
+        optionalStyleEqual:
+          !_definitionParams.required && options.googleClosureSyntax,
+        optionalStyleBrackets:
+          !_definitionParams.required && !options.googleClosureSyntax,
       }
       return overridePropertyParams(propertyParams)
     }),
@@ -65,10 +69,15 @@ const renderNamespace = (params) => {
   const template = getTemplate('namespace')
   return mustache.render(template, params)
 }
-
-const renderJsDoc = (definitionParams) => {
+/**
+ *
+ * @param {object} definitionParams
+ * @param {{googleClosureSyntax: boolean}} options
+ * @return {string}
+ */
+const renderJsDoc = (definitionParams, options) => {
   const template = getTemplate(definitionParams.type)
-  const templateData = paramsOverridesRoot(definitionParams)
+  const templateData = paramsOverridesRoot(definitionParams, options)
   return mustache.render(template, templateData)
 }
 

--- a/src/templates/object.type.tpl.js
+++ b/src/templates/object.type.tpl.js
@@ -3,7 +3,7 @@ const objectTypeTemplate = `
 /**
  * @typedef {<%{ type }%>} <% name %>
  <% #properties %>
- * @property {<%{ type }%><%{ requirednessFlag }%>} <% name %> <%{ description }%>
+ * @property {<%{ type }%><% #optionalStyleEqual %>=<% /optionalStyleEqual %>} <% #optionalStyleBrackets %>[<% /optionalStyleBrackets %><% name %><% #optionalStyleBrackets %>]<% /optionalStyleBrackets %> <%{ description }%>
  <% /properties %>
  * @export
  */

--- a/src/utils/typedefs.js
+++ b/src/utils/typedefs.js
@@ -9,9 +9,22 @@
  */
 
 /**
+ * @typedef {object} PropertyDefinition
+ * @property {string} type
+ * @property {string} format
+ */
+
+/**
+ * @typedef {object} Definition
+ * @property {string} type
+ * @property {array<string>} required
+ * @property {Object<string, PropertyDefinition>} properties
+ */
+
+/**
  * @typedef {object} SwaggerFile
  * @property {String} basePath
- * @property {object} definitions
+ * @property {Object<string, Definition>} definitions
  * @property {Object} externalDocs
  * @property {String} host
  * @property {SwaggerFileInfo} info
@@ -26,7 +39,7 @@
 /**
  * @typedef {object} OpenAPISwaggerFile
  * @property {String} basePath
- * @property {{schemas: object}} components
+ * @property {{schemas: Object<string, Definition>}} components
  * @property {Object} externalDocs
  * @property {String} host
  * @property {SwaggerFileInfo} info


### PR DESCRIPTION
use -g or -googleClosureSyntax to use this syntax
```javascript
/**
...
@param {string=} anOptionalParameter
...
**/
```
Instead of this one (defaults)
```javascript
/**
...
@param {string} [anOptionalParameter]
...
**/

```